### PR TITLE
Add docker repo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM tomcat:latest
+RUN cp -R /usr/local/tomcat/webapps.dist/* /usr/local/tomcat/webapps
+copy ./*.war /usr/local/tomcat/webapps


### PR DESCRIPTION
The Dockerfile is needed to be with the source code so that it is easy to package artifacts and send along with the file for containerisation.